### PR TITLE
[#93659984] Add single quoted String Literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,6 +976,16 @@ in inheritance.
     ```
 ## Strings
 
+* Use single quotes for string literals that do not require interpolation
+
+    ```Ruby
+    # bad, uses double quotes
+    product_name = "My Awesome Product"
+    
+    # good, uses single quotes
+    product_name = 'My Awesome Product'
+    ```
+
 * Prefer string interpolation instead of string concatenation:
 
     ```Ruby


### PR DESCRIPTION
This adds the directive to use single quotes for string literals into the styleguide. This was previously enforced only in PRs by manual review but we should honor the directive to Be Consistent and take a stand on this.

There is an associated PR (liftopia/rtopia#1216) to configure Rubocop to enforce this standard.

RFC @jakefolio @maglfmn @cwd-liftopia 