### PR TITLE
[#121960325] Enforce Ruby 1.9 Hash Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,19 +147,19 @@ characters. Notice techniques like:
 ```ruby
 scope = Translation::Phrase.includes(:phrase_translations).
   joins(:phrase_screenshots).
-  where(:phrase_screenshots => {
-    :controller => controller_name,
-    :action => JAROMIR_JAGR_SALUTE,
+  where(phrase_screenshots: {
+    controller: controller_name,
+    action: JAROMIR_JAGR_SALUTE,
   })
 ```
 
 ```ruby
 translation = FactoryGirl.create(
   :phrase_translation,
-  :locale => :is,
-  :phrase => phrase,
-  :key => 'phone_number_not_revealed_time_zone',
-  :value => 'Símanúmerið þitt verður ekki birt. Það er aðeins hægt að hringja á '\
+  locale: :is,
+  phrase: phrase,
+  key: 'phone_number_not_revealed_time_zone',
+  value: 'Símanúmerið þitt verður ekki birt. Það er aðeins hægt að hringja á '\
             'milli 9:00 og 21:00 %{time_zone}.'
 )
 ```
@@ -175,10 +175,10 @@ end
 ```erb
 <% if @presenter.guest_visa_russia? %>
   <%= icon_tile_for(I18n.t("email.reservation_confirmed_guest.visa.details_header",
-                           :default => "Visa for foreign Travelers"),
-                    :beveled_big_icon => "stamp" do %>
+                           default: "Visa for foreign Travelers"),
+                    beveled_big_icon: "stamp" do %>
     <%= I18n.t("email.reservation_confirmed_guest.visa.russia.details_copy",
-               :default => "Foreign guests travelling to Russia may need to obtain a visa...") %>
+               default: "Foreign guests travelling to Russia may need to obtain a visa...") %>
   <% end %>
 <% end %>
 ```
@@ -186,9 +186,9 @@ end
 These code snippets are very much more readable than the alternative:
 
 ```ruby
-scope = Translation::Phrase.includes(:phrase_translations).joins(:phrase_screenshots).where(:phrase_screenshots => { :controller => controller_name, :action => JAROMIR_JAGR_SALUTE })
+scope = Translation::Phrase.includes(:phrase_translations).joins(:phrase_screenshots).where(phrase_screenshots: { controller: controller_name, action: JAROMIR_JAGR_SALUTE })
 
-translation = FactoryGirl.create(:phrase_translation, :locale => :is, :phrase => phrase, :key => 'phone_number_not_revealed_time_zone', :value => 'Símanúmerið þitt verður ekki birt. Það er aðeins hægt að hringja á milli 9:00 og 21:00 %{time_zone}.')
+translation = FactoryGirl.create(:phrase_translation, locale: :is, phrase: phrase, key: 'phone_number_not_revealed_time_zone', value: 'Símanúmerið þitt verður ekki birt. Það er aðeins hægt að hringja á milli 9:00 og 21:00 %{time_zone}.')
 
 if @reservation_alteration.checkin == @reservation.start_date && @reservation_alteration.checkout == (@reservation.start_date + @reservation.nights)
   redirect_to_alteration @reservation_alteration
@@ -197,8 +197,8 @@ end
 
 ```erb
 <% if @presenter.guest_visa_russia? %>
-  <%= icon_tile_for(I18n.t("email.reservation_confirmed_guest.visa.details_header", :default => "Visa for foreign Travelers"), :beveled_big_icon => "stamp" do %>
-    <%= I18n.t("email.reservation_confirmed_guest.visa.russia.details_copy", :default => "Foreign guests travelling to Russia may need to obtain a visa prior to...") %>
+  <%= icon_tile_for(I18n.t("email.reservation_confirmed_guest.visa.details_header", default: "Visa for foreign Travelers"), beveled_big_icon: "stamp" do %>
+    <%= I18n.t("email.reservation_confirmed_guest.visa.russia.details_copy", default: "Foreign guests travelling to Russia may need to obtain a visa prior to...") %>
   <% end %>
 <% end %>
 ```
@@ -236,10 +236,10 @@ module Translation
   # Australian, New Zealand variations is provided.
   class PrimAndProper
     def initialize
-      @converters = { :en => { :"en-AU" => AmericanToAustralian.new,
-                               :"en-CA" => AmericanToCanadian.new,
-                               :"en-GB" => AmericanToBritish.new,
-                               :"en-NZ" => AmericanToKiwi.new,
+      @converters = { en: { "en-AU": AmericanToAustralian.new,
+                               "en-CA": AmericanToCanadian.new,
+                               "en-GB": AmericanToBritish.new,
+                               "en-NZ": AmericanToKiwi.new,
                              } }
     end
 
@@ -399,9 +399,9 @@ Never leave commented-out code in our codebase.
     # good
     def obliterate(things, options = {})
       default_options = {
-        :gently => true, # obliterate with soft-delete
-        :except => [], # skip obliterating these things
-        :at => Time.now, # don't obliterate them until later
+        gently: true, # obliterate with soft-delete
+        except: [], # skip obliterating these things
+        at: Time.now, # don't obliterate them until later
       }
       options.reverse_merge!(default_options)
 
@@ -459,10 +459,10 @@ Never leave commented-out code in our codebase.
 
     ```ruby
     # bad
-    render(:partial => 'foo')
+    render(partial: 'foo')
 
     # good
-    render :partial => 'foo'
+    render partial: 'foo'
     ```
 
 In either case:
@@ -472,10 +472,10 @@ In either case:
 
     ```ruby
     # bad
-    get '/v1/reservations', { :id => 54875 }
+    get '/v1/reservations', { id: 54875 }
 
     # good
-    get '/v1/reservations', :id => 54875
+    get '/v1/reservations', id: 54875
     ```
 
 ## Conditional Expressions
@@ -904,48 +904,48 @@ in inheritance.
 
     ```Ruby
     # bad
-    hash = { 'one' => 1, 'two' => 2, 'three' => 3 }
+    hash = { 'one': 1, 'two': 2, 'three': 3 }
 
     # good
-    hash = { :one => 1, :two => 2, :three => 3 }
+    hash = { one: 1, two: 2, three: 3 }
     ```
 
-* Always use the hashrocket syntax. Ruby 1.9 hash syntax should not be
+* Always use the Ruby 1.9 hash syntax. Hashrocket syntax should not be
   used.
 
     ```Ruby
     # bad
-    hash = { one: 1, two: 2, three: 3 }
-    
-    # good
     hash = { :one => 1, :two => 2, :three => 3 }
+
+    # good
+    hash = { one: 1, two: 2, three: 3 }
     ```
 
 * Use multi-line hashes when it makes the code more readable, and use
   trailing commas to ensure that parameter changes don't cause
   extraneous diff lines when the logic has not otherwise changed.  
-  
-* Multi-line hashes should be aligned on the hashbang (`=>`).
+
+* Multi-line hashes should be aligned on the value.
 
     ```ruby
     # bad
     hash = {
-      :protocol => 'https',
-      :only_path => false,
-      :controller => :users,
-      :action => :set_password,
-      :redirect => @redirect_url,
-      :secret => @secret,
+      protocol: 'https',
+      only_path: false,
+      controller: :users,
+      action: :set_password,
+      redirect: @redirect_url,
+      secret: @secret,
     }
 
     # good
     hash = {
-      :protocol   => 'https',
-      :only_path  => false,
-      :controller => :users,
-      :action     => :set_password,
-      :redirect   => @redirect_url,
-      :secret     => @secret,
+      protocol:   'https',
+      only_path:  false,
+      controller: :users,
+      action:     :set_password,
+      redirect:   @redirect_url,
+      secret:     @secret,
     }
     ```
 
@@ -953,25 +953,25 @@ in inheritance.
     ```ruby
     # bad
     hash = {
-      :gamma => 3,
-      :beta => 2,
-      :delta => 4,
-      :alpha => 1,
+      gamma: 3,
+      beta: 2,
+      delta: 4,
+      alpha: 1,
     }
-    
+
     # good
     hash = {
-      :alpha => 1,
-      :beta  => 2,
-      :delta => 4,
-      :gamma => 3,
+      alpha: 1,
+      beta: 2,
+      delta: 4,
+      gamma: 3,
     }
-    
+
     # good, required ordering - when you care about Hash#each_pair ordering, for example
     hash = {
-      :subdomain => 'test_resort',
-      :primary   => 'www',
-      :wildcard  => '172.16.25.1',
+      subdomain: 'test_resort',
+      primary: 'www',
+      wildcard: '172.16.25.1',
     }
     ```
 ## Strings
@@ -981,7 +981,7 @@ in inheritance.
     ```Ruby
     # bad, uses double quotes
     product_name = "My Awesome Product"
-    
+
     # good, uses single quotes
     product_name = 'My Awesome Product'
     ```
@@ -1115,18 +1115,18 @@ in inheritance.
 
     ```ruby
     # bad
-    render :text => 'Howdy' and return
+    render text: 'Howdy' and return
 
     # good
-    render :text => 'Howdy'
+    render text: 'Howdy'
     return
 
     # still bad
-    render :text => 'Howdy' and return if foo.present?
+    render text: 'Howdy' and return if foo.present?
 
     # good
     if foo.present?
-      render :text => 'Howdy'
+      render text: 'Howdy'
       return
     end
     ```


### PR DESCRIPTION
**Description:**
- Enforce Ruby 1.9 Hash Syntax
- Related [Rtopia PR](https://github.com/liftopia/rtopia/pull/1700)

**Acceptance criteria:**

``` qa
Styleguide makes sense.
```

**PT stories:** 
- https://www.pivotaltracker.com/story/show/121960325

RFC @liftopia/engineering 
